### PR TITLE
bump min compiler version down to 0.12

### DIFF
--- a/cvssc/0.2.1/typst.toml
+++ b/cvssc/0.2.1/typst.toml
@@ -10,4 +10,4 @@ repository = "https://github.com/drakeaxelrod/cvssc"
 keywords = ["cvss", "security", "vulnerability", "scoring"]
 categories = ["utility"]
 disciplines = ["computer-science"]
-compiler = "0.14.0"
+compiler = "0.12.0"


### PR DESCRIPTION
This fixes https://github.com/drakeaxelrod/cvssc/issues/4 

Every *.typ file in in the `\cvssc\0.2.1` folder compiles with typst 0.12.0 and all tests pass (165/165).